### PR TITLE
[Feat] Automatically download dashboard through nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 ﻿# AspireRunner
 
-A standalone runner for the .NET [Aspire Dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone) which can be used to display OpenTelemetry
-data (traces, metrics, and logs) from any application.
+A standalone runner for the .NET [Aspire Dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone) which can display OpenTelemetry data (traces,
+metrics, and logs) from any application.
+
+The runner can be used as a [dotnet tool](./src/AspireRunner.Tool/README.md) or as part of an [ASP.NET Core application](./src/AspireRunner.AspNetCore/README.md), it will automatically download the dashboard if it's not installed, and will run and manage the dashboard process.
 
 > [!NOTE]
-> Currently, the runner requires both the .NET 8 SDK and the [aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=dotnet-cli%2Cunix) to
-> be installed.
+> The runner will prioritize using the dashboard bundled with the [Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=windows&pivots=visual-studio), if it's installed.
+
+> [!IMPORTANT]
+> While the runner itself targets .NET 6 (and later), the dashboard requires the .NET 8/9 runtime to run.
 >
->
-> Eventually (wip), it'll be able to automatically fetch and install the dashboard and therefore would only require the .NET runtime.
+> Meaning that the runner can be used as part of a .NET 6 application, but you still need to have the .NET 8/9 runtime installed to run the dashboard.
+
 
 ## [AspireRunner.Tool](./src/AspireRunner.Tool/README.md)
 
-Provides an easy to use dotnet tool for running the Dashboard
+Provides an easy to use dotnet tool for downloading and running the Dashboard
 
 [![NuGet Version](https://img.shields.io/nuget/vpre/AspireRunner.Tool?style=flat&logo=nuget&color=%230078d4&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FAspireRunner.Tool)](https://www.nuget.org/packages/AspireRunner.Tool)
 
 ### Installation
 
 ```bash
-# Install the aspire workload (skip if already installed)
-dotnet workload install aspire
-
-# Install the AspireRunner tool
 dotnet tool install -g AspireRunner.Tool
 ```
 

--- a/src/AspireRunner.Core/AspireDashboard.Constants.cs
+++ b/src/AspireRunner.Core/AspireDashboard.Constants.cs
@@ -8,6 +8,8 @@ public partial class AspireDashboard
 
     private const string DllName = "Aspire.Dashboard.dll";
 
+    private const string AspRuntimeName = "Microsoft.AspNetCore.App";
+
     private const string DataFolder = ".AspireRunner";
 
     private const string InstanceFile = "aspire-dashboard.pid";

--- a/src/AspireRunner.Core/AspireDashboard.Constants.cs
+++ b/src/AspireRunner.Core/AspireDashboard.Constants.cs
@@ -12,6 +12,8 @@ public partial class AspireDashboard
 
     private const string DataFolder = ".AspireRunner";
 
+    private const string DownloadFolder = "dashboard";
+
     private const string InstanceFile = "aspire-dashboard.pid";
 
     private const string LoginConsoleMessage = "Login to the dashboard at";

--- a/src/AspireRunner.Core/AspireDashboard.Constants.cs
+++ b/src/AspireRunner.Core/AspireDashboard.Constants.cs
@@ -21,4 +21,6 @@ public partial class AspireDashboard
     private const string DashboardStartedConsoleMessage = "Now listening on:";
 
     private const int DefaultErrorLogDelay = 2000;
+
+    private static readonly Version MinimumRuntimeVersion = new(8, 0, 0);
 }

--- a/src/AspireRunner.Core/AspireDashboard.Regex.cs
+++ b/src/AspireRunner.Core/AspireDashboard.Regex.cs
@@ -4,6 +4,5 @@ namespace AspireRunner.Core;
 
 public partial class AspireDashboard
 {
-    [GeneratedRegex(@$"((?:{LoginConsoleMessage})|(?:{DashboardStartedConsoleMessage})) +(?<url>https?:\/\/[^\s]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
-    private static partial Regex LaunchUrlRegex();
+    private static readonly Regex LaunchUrlRegex = new(@$"((?:{LoginConsoleMessage})|(?:{DashboardStartedConsoleMessage})) +(?<url>https?:\/\/[^\s]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 }

--- a/src/AspireRunner.Core/AspireDashboard.cs
+++ b/src/AspireRunner.Core/AspireDashboard.cs
@@ -63,7 +63,7 @@ public partial class AspireDashboard
         }
 
         var installedRuntimes = _dotnetCli.GetInstalledRuntimes()
-            .Where(r => r.Name is AspRuntimeName)
+            .Where(r => r.Name is AspRuntimeName && r.Version >= MinimumRuntimeVersion)
             .Select(r => r.Version)
             .ToArray();
 
@@ -214,9 +214,9 @@ public partial class AspireDashboard
 
             var versionToDownload = (
                 preferredVersion != null
-                    ? availableVersions.Where(v => v.IsCompatibleWith(preferredVersion)).Max()
+                    ? availableVersions.Where(preferredVersion.IsCompatibleWith).Max()
                     : availableVersions.Where(v => v.Major == latestRuntimeVersion!.Major).Max()
-            ) ?? availableVersions.First(v => !v.IsPreRelease);
+            ) ?? availableVersions.First(v => !v.IsPreRelease); // Fallback to the latest non-preview version
 
             return await _nugetHelper.DownloadPackageAsync(_nugetPackageName, versionToDownload, Path.Combine(_runnerFolder, DownloadFolder, versionToDownload.ToString()));
         }
@@ -241,7 +241,7 @@ public partial class AspireDashboard
                 : installedVersions.Max();
 
             var latestAvailableVersion = preferredVersion != null
-                ? availableVersions.Where(v => v.IsCompatibleWith(preferredVersion)).Max()
+                ? availableVersions.Where(preferredVersion.IsCompatibleWith).Max()
                 : availableVersions.Where(v => v.Major == latestInstalledVersion!.Major).Max();
 
             if (latestAvailableVersion > latestInstalledVersion)

--- a/src/AspireRunner.Core/AspireDashboard.cs
+++ b/src/AspireRunner.Core/AspireDashboard.cs
@@ -1,4 +1,5 @@
 ﻿using AspireRunner.Core.Extensions;
+using AspireRunner.Core.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;

--- a/src/AspireRunner.Core/AspireDashboard.cs
+++ b/src/AspireRunner.Core/AspireDashboard.cs
@@ -160,7 +160,7 @@ public partial class AspireDashboard
         }
 
         return (
-            Installed: Directory.EnumerateDirectories(downloadsFolder, "v*").Any(),
+            Installed: Directory.EnumerateDirectories(downloadsFolder, "*.*").Any(),
             Workload: false
         );
     }
@@ -292,7 +292,7 @@ public partial class AspireDashboard
 
             if (Version.TryParse(_options.Runner.RuntimeVersion, out var preferredVersion))
             {
-                var preferredDashboard = installedVersions.Where(v => v.Version.IsCompatibleWith(preferredVersion)).Max();
+                var preferredDashboard = installedVersions.FirstOrDefault(v => v.Version.IsCompatibleWith(preferredVersion));
                 if (preferredDashboard.Path != null)
                 {
                     return Path.Combine(preferredDashboard.Path, "tools");

--- a/src/AspireRunner.Core/AspireDashboard.cs
+++ b/src/AspireRunner.Core/AspireDashboard.cs
@@ -348,7 +348,7 @@ public partial class AspireDashboard
             return;
         }
 
-        if (LaunchUrlRegex().Match(output) is { Success: true } match)
+        if (LaunchUrlRegex.Match(output) is { Success: true } match)
         {
             var url = match.Groups["url"].Value;
             if (_options.Runner.LaunchBrowser)

--- a/src/AspireRunner.Core/AspireDashboardOptions.cs
+++ b/src/AspireRunner.Core/AspireDashboardOptions.cs
@@ -113,6 +113,9 @@ public sealed class RunnerOptions
     /// <summary>
     /// The version of the dotnet runtime to use when downloading/running the dashboard.
     /// </summary>
+    /// <example>
+    /// When setting the runtime version to 8.0, the latest 8.x version of the dashboard will be downloaded/used.
+    /// </example>
     public string? RuntimeVersion { get; set; }
 }
 

--- a/src/AspireRunner.Core/AspireDashboardOptions.cs
+++ b/src/AspireRunner.Core/AspireDashboardOptions.cs
@@ -104,6 +104,16 @@ public sealed class RunnerOptions
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public SingleInstanceHandling SingleInstanceHandling { get; set; } = SingleInstanceHandling.WarnAndExit;
+
+    /// <summary>
+    /// Automatically download the dashboard if the workload is not found.
+    /// </summary>
+    public bool AutoDownload { get; set; }
+
+    /// <summary>
+    /// The version of the dotnet runtime to use when downloading/running the dashboard.
+    /// </summary>
+    public string? RuntimeVersion { get; set; }
 }
 
 public enum FrontendAuthMode

--- a/src/AspireRunner.Core/AspireRunner.Core.csproj
+++ b/src/AspireRunner.Core/AspireRunner.Core.csproj
@@ -33,6 +33,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
+        <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2"/>
     </ItemGroup>
 </Project>

--- a/src/AspireRunner.Core/AspireRunner.Core.csproj
+++ b/src/AspireRunner.Core/AspireRunner.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.0.3</Version>
+        <Version>1.1.0</Version>
         <TargetFramework>net8.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
 

--- a/src/AspireRunner.Core/AspireRunner.Core.csproj
+++ b/src/AspireRunner.Core/AspireRunner.Core.csproj
@@ -2,8 +2,9 @@
 
     <PropertyGroup>
         <Version>1.1.0</Version>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+        <langversion>latest</langversion>
 
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -36,4 +37,9 @@
         <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2"/>
     </ItemGroup>
+
+    <ItemGroup Condition="('$(TargetFramework)'=='net6.0') Or ('$(TargetFramework)'=='net7.0') ">
+        <PackageReference Include="System.Text.Json" Version="8.0.3"/>
+    </ItemGroup>
+
 </Project>

--- a/src/AspireRunner.Core/Extensions/VersionExtensions.cs
+++ b/src/AspireRunner.Core/Extensions/VersionExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace AspireRunner.Core.Extensions;
+
+public static class VersionExtensions
+{
+    public static bool IsCompatibleWith(this Version version, Version other)
+    {
+        if (version.Major != other.Major)
+        {
+            return false;
+        }
+
+        if (version.Minor < other.Minor)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
@@ -4,15 +4,11 @@ namespace AspireRunner.Core.Helpers;
 
 public partial class DotnetCli
 {
-    [GeneratedRegex(@"([\d\.]+)\s+(?:\[(.+)\])?", RegexOptions.Compiled)]
-    private static partial Regex SdkOutputRegex();
+    private static readonly Regex SdkOutputRegex = new(@"([\d\.]+)\s+(?:\[(.+)\])?", RegexOptions.Compiled);
 
-    [GeneratedRegex(@"(.+?) ([\d\-_.\w]+?) \[(.+)\]", RegexOptions.Compiled)]
-    private static partial Regex RuntimeOutputRegex();
+    private static readonly Regex RuntimeOutputRegex = new(@"(.+?) ([\d\-_.\w]+?) \[(.+)\]", RegexOptions.Compiled);
 
-    [GeneratedRegex(@"-+\r?\n([\w\W]+?)\r?\n\r?\n", RegexOptions.Compiled)]
-    private static partial Regex TableContentRegex();
+    private static readonly Regex TableContentRegex = new(@"-+\r?\n([\w\W]+?)\r?\n\r?\n", RegexOptions.Compiled);
 
-    [GeneratedRegex(@"\s{2,}", RegexOptions.Compiled)]
-    private static partial Regex TableColumnSeperatorRegex();
+    private static readonly Regex TableColumnSeperatorRegex = new(@"\s{2,}", RegexOptions.Compiled);
 }

--- a/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
@@ -1,15 +1,18 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace AspireRunner.Core;
+namespace AspireRunner.Core.Helpers;
 
 public partial class DotnetCli
 {
     [GeneratedRegex(@"([\d\.]+)\s+(?:\[(.+)\])?", RegexOptions.Compiled)]
     private static partial Regex SdkOutputRegex();
 
+    [GeneratedRegex(@"(.+?) ([\d\-_.\w]+?) \[(.+)\]", RegexOptions.Compiled)]
+    private static partial Regex RuntimeOutputRegex();
+
     [GeneratedRegex(@"-+\r?\n([\w\W]+?)\r?\n\r?\n", RegexOptions.Compiled)]
     private static partial Regex TableContentRegex();
 
-    [GeneratedRegex(@"\s{2,}")]
+    [GeneratedRegex(@"\s{2,}", RegexOptions.Compiled)]
     private static partial Regex TableColumnSeperatorRegex();
 }

--- a/src/AspireRunner.Core/Helpers/DotnetCli.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.cs
@@ -179,7 +179,7 @@ public partial class DotnetCli
     /// Returns all installed runtimes.
     /// </summary>
     /// <returns>A tuple array containing the name and version of each installed runtime</returns>
-    public (string Runtime, string Version)[] GetInstalledRuntimes()
+    public (string Name, Version Version)[] GetInstalledRuntimes()
     {
         var runtimesOutput = Run("--list-runtimes");
         if (string.IsNullOrWhiteSpace(runtimesOutput))
@@ -190,7 +190,7 @@ public partial class DotnetCli
         return runtimesOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
             .Select(s => RuntimeOutputRegex().Match(s))
             .Where(m => m.Success)
-            .Select(m => (Runtime: m.Groups[1].Value, Version: m.Groups[2].Value))
+            .Select(m => (Name: m.Groups[1].Value, Version: new Version(m.Groups[2].Value)))
             .ToArray();
     }
 

--- a/src/AspireRunner.Core/Helpers/DotnetCli.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.cs
@@ -75,7 +75,7 @@ public partial class DotnetCli
     /// <exception cref="InvalidOperationException">The dotnet CLI process failed to start.</exception>
     public Process Run(string[] arguments, string? workingDirectory = null, IDictionary<string, string>? environement = null, Action<string>? outputHandler = null, Action<string>? errorHandler = null)
     {
-        var processStartInfo = new ProcessStartInfo(Path.Combine(CliPath, Executable), arguments)
+        var processStartInfo = new ProcessStartInfo(Path.Combine(CliPath, Executable))
         {
             CreateNoWindow = true,
             UseShellExecute = false,
@@ -84,6 +84,11 @@ public partial class DotnetCli
             WorkingDirectory = workingDirectory,
             WindowStyle = ProcessWindowStyle.Hidden
         };
+
+        foreach (var argument in arguments)
+        {
+            processStartInfo.ArgumentList.Add(argument);
+        }
 
         if (environement != null)
         {
@@ -162,7 +167,7 @@ public partial class DotnetCli
     public string[] GetInstalledWorkloads()
     {
         var workloadsOutput = Run("workload list");
-        var workloadsMatch = TableContentRegex().Match(workloadsOutput);
+        var workloadsMatch = TableContentRegex.Match(workloadsOutput);
         if (!workloadsMatch.Success)
         {
             return [];
@@ -170,7 +175,7 @@ public partial class DotnetCli
 
         return workloadsMatch.Value
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-            .Select(row => TableColumnSeperatorRegex().Split(row, 3)[0])
+            .Select(row => TableColumnSeperatorRegex.Split(row, 3)[0])
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .ToArray();
     }
@@ -188,7 +193,7 @@ public partial class DotnetCli
         }
 
         return runtimesOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-            .Select(s => RuntimeOutputRegex().Match(s))
+            .Select(s => RuntimeOutputRegex.Match(s))
             .Where(m => m.Success)
             .Select(m => (Name: m.Groups[1].Value, Version: new Version(m.Groups[2].Value)))
             .ToArray();
@@ -202,7 +207,7 @@ public partial class DotnetCli
     {
         var sdksOutput = Run("--list-sdks");
         var sdks = sdksOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-            .Select(s => SdkOutputRegex().Match(s))
+            .Select(s => SdkOutputRegex.Match(s))
             .Where(m => m.Success)
             .Select(m => (Version: m.Groups[1].Value, Path: m.Groups[2].Value))
             .ToArray();

--- a/src/AspireRunner.Core/Helpers/DotnetCli.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 
-namespace AspireRunner.Core;
+namespace AspireRunner.Core.Helpers;
 
 public partial class DotnetCli
 {
@@ -17,10 +17,10 @@ public partial class DotnetCli
     private DotnetCli() { }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="AspireRunner.Core.DotnetCli"/> class.
+    /// Creates a new instance of the <see cref="DotnetCli"/> class.
     /// </summary>
     /// <returns>
-    /// A new instance of the <see cref="AspireRunner.Core.DotnetCli"/> class or null if the dotnet CLI wasn't found.
+    /// A new instance of the <see cref="DotnetCli"/> class or null if the dotnet CLI wasn't found.
     /// </returns>
     public static DotnetCli? TryCreate()
     {
@@ -176,6 +176,25 @@ public partial class DotnetCli
     }
 
     /// <summary>
+    /// Returns all installed runtimes.
+    /// </summary>
+    /// <returns>A tuple array containing the name and version of each installed runtime</returns>
+    public (string Runtime, string Version)[] GetInstalledRuntimes()
+    {
+        var runtimesOutput = Run("--list-runtimes");
+        if (string.IsNullOrWhiteSpace(runtimesOutput))
+        {
+            return [];
+        }
+
+        return runtimesOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Select(s => RuntimeOutputRegex().Match(s))
+            .Where(m => m.Success)
+            .Select(m => (Runtime: m.Groups[1].Value, Version: m.Groups[2].Value))
+            .ToArray();
+    }
+
+    /// <summary>
     /// Returns the path of the latest SDK installed.
     /// </summary>
     /// <returns>The path of the latest SDK installed or null if no SDK was found.</returns>
@@ -262,7 +281,6 @@ public partial class DotnetCli
 
         return paths;
     }
-
 
     /// <summary>
     /// Checks if the current process is running inside WSL.

--- a/src/AspireRunner.Core/Helpers/NugetHelper.cs
+++ b/src/AspireRunner.Core/Helpers/NugetHelper.cs
@@ -14,15 +14,15 @@ public class NugetHelper(ILogger<NugetHelper> logger)
     private readonly SourceCacheContext _cache = new();
     private readonly SourceRepository _repository = Repository.Factory.GetCoreV3(RepoUrl);
 
-    public async Task<Version[]> GetPackageVersions(string packageName)
+    public async Task<Version[]> GetPackageVersionsAsync(string packageName)
     {
         var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
         var metadata = await resource.GetAllVersionsAsync(packageName, _cache, NullLogger.Instance, CancellationToken.None);
 
-        return metadata.Select(v => new Version(v.ToFullString(), true)).ToArray();
+        return metadata.Select(v => new Version(v.ToFullString(), true)).OrderDescending().ToArray();
     }
 
-    public async Task<bool> DownloadPackage(string packageName, Version version, string destinationPath)
+    public async Task<bool> DownloadPackageAsync(string packageName, Version version, string destinationPath)
     {
         using var packageStream = new MemoryStream();
         var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();

--- a/src/AspireRunner.Core/Helpers/NugetHelper.cs
+++ b/src/AspireRunner.Core/Helpers/NugetHelper.cs
@@ -19,7 +19,7 @@ public class NugetHelper(ILogger<NugetHelper> logger)
         var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
         var metadata = await resource.GetAllVersionsAsync(packageName, _cache, NullLogger.Instance, CancellationToken.None);
 
-        return metadata.Select(v => new Version(v.ToFullString(), true)).OrderDescending().ToArray();
+        return metadata.Select(v => new Version(v.ToFullString(), true)).OrderByDescending(v => v).ToArray();
     }
 
     public async Task<bool> DownloadPackageAsync(string packageName, Version version, string destinationPath)

--- a/src/AspireRunner.Core/Helpers/NugetHelper.cs
+++ b/src/AspireRunner.Core/Helpers/NugetHelper.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace AspireRunner.Core.Helpers;
+
+public class NugetHelper(ILogger<NugetHelper> logger)
+{
+    private const string RepoUrl = "https://api.nuget.org/v3/index.json";
+
+    private readonly SourceCacheContext _cache = new();
+    private readonly SourceRepository _repository = Repository.Factory.GetCoreV3(RepoUrl);
+
+    public async Task<Version[]> GetPackageVersions(string packageName)
+    {
+        var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+        var metadata = await resource.GetAllVersionsAsync(packageName, _cache, NullLogger.Instance, CancellationToken.None);
+
+        return metadata.Select(v => new Version(v.ToFullString(), true)).ToArray();
+    }
+
+    public async Task<bool> DownloadPackage(string packageName, Version version, string destinationPath)
+    {
+        using var packageStream = new MemoryStream();
+        var resource = await _repository.GetResourceAsync<FindPackageByIdResource>();
+
+        logger.LogTrace("Downloading {PackageName} {Version} to {DestinationPath}", packageName, version, destinationPath);
+
+        var success = await resource.CopyNupkgToStreamAsync(
+            packageName,
+            new NuGetVersion(version.ToString()),
+            packageStream,
+            _cache,
+            NullLogger.Instance,
+            CancellationToken.None
+        );
+
+        if (!success)
+        {
+            return false;
+        }
+
+        using var packageReader = new PackageArchiveReader(packageStream);
+        await packageReader.CopyFilesAsync(destinationPath, packageReader.GetFiles(), ExtractFile, NullLogger.Instance, CancellationToken.None);
+
+        return true;
+    }
+
+    private string ExtractFile(string sourcefile, string targetpath, Stream filestream)
+    {
+        logger.LogTrace("Extracting {SourceFile} to {TargetPath}", sourcefile, targetpath);
+
+        using var file = File.Create(targetpath);
+        filestream.CopyTo(file);
+
+        return targetpath;
+    }
+}

--- a/src/AspireRunner.Tool/Arguments.cs
+++ b/src/AspireRunner.Tool/Arguments.cs
@@ -22,6 +22,15 @@ public record Arguments
     [Option('a', "auth", HelpText = "Use browser token authentication for the dashboard")]
     public bool UseAuth { get; init; }
 
-    [Option('m', "multiple", HelpText = "Allow running multiple instances of the dashboard")]
+    [Option('m', "multiple", HelpText = "Allow running multiple instances of the dashboard, if this isn't passed, existing instances will be replaced")]
     public bool AllowMultipleInstances { get; set; }
+
+    [Option('r', "runtime-version", HelpText = "The version of the .NET runtime to use")]
+    public string? RuntimeVersion { get; set; }
+
+    [Option('d', "auto-download", Default = true, HelpText = "Automatically download the dashboard if it's not installed")]
+    public bool AutoDownload { get; set; }
+
+    [Option('v', "Verbose", HelpText = "Enable verbose logging")]
+    public bool Verbose { get; set; }
 }

--- a/src/AspireRunner.Tool/AspireRunner.Tool.csproj
+++ b/src/AspireRunner.Tool/AspireRunner.Tool.csproj
@@ -3,8 +3,9 @@
     <PropertyGroup>
         <Version>1.1.0</Version>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+        <langversion>latest</langversion>
 
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/AspireRunner.Tool/AspireRunner.Tool.csproj
+++ b/src/AspireRunner.Tool/AspireRunner.Tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.0.3</Version>
+        <Version>1.1.0</Version>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>

--- a/src/AspireRunner.Tool/ConsoleLogger.cs
+++ b/src/AspireRunner.Tool/ConsoleLogger.cs
@@ -4,15 +4,22 @@ namespace AspireRunner.Tool;
 
 public class ConsoleLogger<T> : ILogger<T>
 {
+    public bool Verbose { get; set; }
+
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
         var message = formatter(state, exception);
         if (string.IsNullOrWhiteSpace(message))
         {
             return;
         }
 
-        if (logLevel == LogLevel.Error)
+        if (logLevel == LogLevel.Error || exception is not null)
         {
             Console.Write(Bold().Red("Error "));
         }
@@ -20,11 +27,15 @@ public class ConsoleLogger<T> : ILogger<T>
         {
             Console.Write(Bold().Yellow("Warning "));
         }
+        else if (logLevel is LogLevel.Trace or LogLevel.Debug)
+        {
+            Console.Write(Bold().Cyan("Debug "));
+        }
 
         Console.WriteLine(message);
     }
 
-    public bool IsEnabled(LogLevel logLevel) => true;
+    public bool IsEnabled(LogLevel logLevel) => Verbose || logLevel is not (LogLevel.Debug or LogLevel.Trace);
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 }

--- a/src/AspireRunner.Tool/Program.cs
+++ b/src/AspireRunner.Tool/Program.cs
@@ -1,4 +1,5 @@
 ﻿using AspireRunner.Core;
+using AspireRunner.Core.Helpers;
 using AspireRunner.Tool;
 using CommandLine;
 using CommandLine.Text;

--- a/src/AspireRunner.Tool/README.md
+++ b/src/AspireRunner.Tool/README.md
@@ -1,42 +1,48 @@
-﻿## AspireRunner
+﻿## AspireRunner.Tool
 
-A dotnet tool for running the Aspire Dashboard that's bundled with the [aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=dotnet-cli%2Cunix).
+A dotnet tool for downloading and running the standalone [Aspire Dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone)
 
-The dashboard can be used to display OpenTelemetry data (traces, metrics, and logs) from any application ([more info](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/overview))
+The dashboard can display OpenTelemetry data (traces, metrics, and logs) from any application ([more info](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/overview)).
 
 [![NuGet Version](https://img.shields.io/nuget/vpre/AspireRunner.Tool?style=flat&logo=nuget&color=%230078d4&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FAspireRunner.Tool)](https://www.nuget.org/packages/AspireRunner.Tool)
 
 ## Installation
 
 ```bash
-# Install the aspire workload (skip if already installed)
-dotnet workload install aspire
-
 # Install the AspireRunner tool
 dotnet tool install -g AspireRunner.Tool
 ```
 
 ## Usage
 
-```bash
+```
 aspire-dashboard <options>
 
 Options:
-  -b, --browser      Launch the dashboard in the default browser
+  -b, --browser            Launch the dashboard in the default browser
 
-  -p, --port         (Default: 18888) The port the dashboard will be available on
+  -p, --port               (Default: 18888) The port the dashboard will be available on
 
-  -o, --otlp-port    (Default: 4317) The port the OTLP server will listen on
+  -o, --otlp-port          (Default: 4317) The port the OTLP server will listen on
 
-  -k, --otlp-key     The API key to use for the OTLP server
+  -k, --otlp-key           The API key to use for the OTLP server
 
-  -s, --https        (Default: true) Use HTTPS instead of HTTP, this applies to both the dashboard and the OTLP server
+  -s, --https              (Default: true) Use HTTPS instead of HTTP, this applies to both the dashboard and the OTLP server
 
-  -a, --auth         Use browser token authentication for the dashboard
+  -a, --auth               Use browser token authentication for the dashboard
 
-  -m, --multiple     Allow running multiple instances of the dashboard
+  -m, --multiple           Allow running multiple instances of the dashboard, if this isn't passed, existing instances will be replaced
 
-  --help             Display this help screen.
+  -r, --runtime-version    The version of the .NET runtime to use
 
-  --version          Display version information.
+  -d, --auto-download      (Default: true) Automatically download the dashboard if it's not installed
+
+  -v, --Verbose            Enable verbose logging
+
+  --help                   Display this help screen.
+
+  --version                Display version information.
 ```
+
+> [!NOTE]
+> The runner will prioritize using the dashboard bundled with the [Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=windows&pivots=visual-studio), if it's installed.


### PR DESCRIPTION
- The download functionality will only be used if the workload is not installed.

- The runner will check if there are any matching dashboards previously downloaded and use them

- Otherwise, the runner will fetch the available dashboard versions from [nuget.org](https://www.nuget.org/packages?q=Aspire.Dashboard.Sdk) based on the running [RID](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)

- The runner will select the appropriate version to download based on the passed runtime version option or the latest installed runtime, passed option should be validated against installed runtimes and against available dashboard versions (major runtime version should match major dashboard version)

- The runner will extract the downloaded package in the data folder (.AspireRunner)