### PR TITLE
fix: skip versions that are not parseble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ riderModule.iml
 /**/.idea
 /**/nupkg
 /**/dist
+/.cr/personal/FavoritesList
+/.vs/AspireRunner

--- a/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.Regex.cs
@@ -4,7 +4,7 @@ namespace AspireRunner.Core.Helpers;
 
 public partial class DotnetCli
 {
-    private static readonly Regex SdkOutputRegex = new(@"([\d\.]+)\s+(?:\[(.+)\])?", RegexOptions.Compiled);
+    private static readonly Regex SdkOutputRegex = new(@"([\d\.\w\-]+?)\s+(?:\[(.+)\])?", RegexOptions.Compiled);
 
     private static readonly Regex RuntimeOutputRegex = new(@"(.+?) ([\d\-_.\w]+?) \[(.+)\]", RegexOptions.Compiled);
 

--- a/src/AspireRunner.Core/Helpers/DotnetCli.cs
+++ b/src/AspireRunner.Core/Helpers/DotnetCli.cs
@@ -202,7 +202,9 @@ public partial class DotnetCli(ILogger<DotnetCli> logger)
             return null;
         }
 
-        var latestSdk = sdks.MaxBy(s => new Version(s.Version));
+        var latestSdk = sdks
+            .Where(s => Version.TryParse(s.Version, out var _))
+            .MaxBy(s => Version.Parse(s.Version));
         return Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(latestSdk.Path));
     }
 


### PR DESCRIPTION
i have an release candidate installed, and that version, for example 8.0.0-rc.1.23420.5, couldnt be parsed.